### PR TITLE
partial #27 - removing CPU time limits because that's a paid feature …

### DIFF
--- a/workers/tangram-calendar-submit/wrangler.jsonc
+++ b/workers/tangram-calendar-submit/wrangler.jsonc
@@ -18,9 +18,6 @@
       "custom_domain": true
     }
   ],
-  "limits": {
-    "cpu_ms": 50
-  },
   "kv_namespaces": [
     {
       "id": "5257dbd282424ab2b434e688642abc1e",

--- a/workers/tangram-calendar/wrangler.jsonc
+++ b/workers/tangram-calendar/wrangler.jsonc
@@ -18,9 +18,6 @@
       "custom_domain": true
     }
   ],
-  "limits": {
-    "cpu_ms": 50
-  },
   "kv_namespaces": [
     {
       "id": "5257dbd282424ab2b434e688642abc1e",


### PR DESCRIPTION
…and deploys are prevented when you're on the free plan